### PR TITLE
Extending ESLint recommended rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,7 @@
     "es2020": true,
     "node": true
   },
-  "extends": ["next", "plugin:prettier/recommended"],
+  "extends": ["eslint:recommended", "next", "plugin:prettier/recommended"],
   "plugins": ["@emotion"],
   "rules": {
     "@emotion/import-from-emotion": "error",

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -1,6 +1,6 @@
-import { Global, css, styled } from '@emotion/react';
-import Head from 'next/head';
+import { Global, css } from '@emotion/react';
 import emotionNormalize from 'emotion-normalize';
+import Head from 'next/head';
 
 const App = ({ Component, pageProps }) => (
   <>


### PR DESCRIPTION
Extending ESLint recommended rules to avail of sensible defaults such as [no-unused-vars](https://eslint.org/docs/rules/no-unused-vars)