### PR TITLE
Pokedex individual page

### DIFF
--- a/components/button/button.jsx
+++ b/components/button/button.jsx
@@ -79,7 +79,7 @@ export const TertiaryButton = styled(Button)`
   &::before {
     content: '🔗';
     display: inline-block;
-    margin-right: 0.2rem;
+    margin-right: 0.5rem;
   }
 
   &:hover,

--- a/components/layout/layout.jsx
+++ b/components/layout/layout.jsx
@@ -34,10 +34,6 @@ const AppHeader = styled.header`
   transition: background-color 200ms;
 `;
 
-const SiteTitle = styled(H1)`
-  margin: 0;
-`;
-
 const SiteTitleLink = styled('a')`
   color: ${secondaryColors.get(500)};
   display: block;
@@ -94,11 +90,11 @@ const Layout = ({ children }) => {
       <GlobalStyles />
       <AppWrapper>
         <AppHeader>
-          <SiteTitle>
+          <H1 mb={0}>
             <Link href="/" passHref>
               <SiteTitleLink>Pokedex</SiteTitleLink>
             </Link>
-          </SiteTitle>
+          </H1>
           <LogoWrapper ratio="1 / 1">
             <PokeballComponent />
           </LogoWrapper>

--- a/pages/pokemon/[name].jsx
+++ b/pages/pokemon/[name].jsx
@@ -1,0 +1,273 @@
+import Head from 'next/head';
+import styled from '@emotion/styled';
+import AspectRatioImage from 'components/aspect-ratio-image';
+import { TertiaryButton } from 'components/button';
+import { H2, H3, Paragraph } from 'components/typography';
+import { fetchPokemon } from 'services/pokeapi';
+import * as breakpoints from 'utils/breakpoints';
+import { textColors } from 'utils/colors';
+import { spacing, typeScale } from 'utils/typography';
+
+export const getServerSideProps = async (context) => {
+  const pokemon = await fetchPokemon({
+    slug: context.params.name,
+    includeTypes: true,
+  });
+
+  return {
+    props: {
+      pokemon,
+    },
+  };
+};
+
+const typeColorMap = new Map([
+  ['normal', '#A8A77A'],
+  ['fire', '#EE8130'],
+  ['water', '#6390F0'],
+  ['electric', '#F7D02C'],
+  ['grass', '#7AC74C'],
+  ['ice', '#96D9D6'],
+  ['fighting', '#C22E28'],
+  ['poison', '#A33EA1'],
+  ['ground', '#E2BF65'],
+  ['flying', '#A98FF3'],
+  ['psychic', '#F95587'],
+  ['bug', '#A6B91A'],
+  ['rock', '#B6A136'],
+  ['ghost', '#735797'],
+  ['dragon', '#6F35FC'],
+  ['dark', '#705746'],
+  ['steel', '#B7B7CE'],
+  ['fairy', '#D685AD'],
+]);
+
+const statSlagToName = new Map([
+  ['hp', 'HP'],
+  ['attack', 'Attack'],
+  ['defense', 'Defense'],
+  ['special-attack', 'Special Attack'],
+  ['special-defense', 'Special Defense'],
+  ['speed', 'Speed'],
+]);
+
+const HeaderWrapper = styled('header')`
+  margin-bottom: ${spacing.get(2)};
+`;
+
+const ChipWrapper = styled('div')`
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: flex-start;
+`;
+
+const Chip = styled('div')`
+  background: ${({ type }) => typeColorMap.get(type)};
+  border-radius: 0.3rem;
+  color: ${textColors.get('inverted')};
+  flex: 0 0 auto;
+  font-size: ${typeScale.get('paragraph')};
+  font-weight: bold;
+  padding: 0.6rem;
+  text-align: center;
+  text-shadow: 0.1rem 0.1rem 0.1rem ${textColors.get('default')};
+`;
+
+const InsightsWrapper = styled('div')`
+  align-items: stretch;
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.get(1)};
+  justify-content: flex-start;
+  margin-bottom: ${spacing.get(4)};
+
+  ${breakpoints.up('md')} {
+    align-items: flex-start;
+    flex-direction: row;
+  }
+`;
+
+const PokemonImage = styled(AspectRatioImage)`
+  margin: 0 auto;
+  max-width: 47.5rem;
+  width: 100%;
+
+  ${breakpoints.up('md')} {
+    margin: 0;
+    width: 50%;
+  }
+`;
+
+const StatList = styled('ul')`
+  flex: 1 1 50%;
+  margin: 0;
+  padding: 0;
+`;
+
+const StatListItem = styled('li')`
+  list-style: none;
+  margin-bottom: ${spacing.get(2)};
+
+  :last-child {
+    margin-bottom: 0;
+  }
+`;
+
+const StatTrack = styled('div')`
+  background-color: ${({ theme }) => theme.disabledColor};
+  border: 0.3rem solid ${({ theme }) => theme.primaryBorderColor};
+  border-radius: 2.5rem;
+  display: block;
+  height: 2.5rem;
+  overflow: hidden;
+  width: 100%;
+`;
+
+const StatFill = styled('div')`
+  align-items: center;
+  background-color: ${({ theme }) => theme.primaryHoverColor};
+  display: flex;
+  font-size: ${typeScale.get('paragraph')};
+  font-weight: 700;
+  flex-direction: row;
+  justify-content: flex-start;
+  height: 100%;
+  padding: 0 1.3rem;
+`;
+
+const ProfileWrapper = styled('div')``;
+
+const DescriptionList = styled('dl')`
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  font-size: ${typeScale.get('paragraph')};
+  justify-content: flex-start;
+  gap: 0.8rem;
+  margin: 0 0 ${spacing.get(2)} 0;
+
+  ${breakpoints.up('md')} {
+    flex-direction: row;
+  }
+`;
+
+const DescriptionSet = styled('div')`
+  flex: 1 1 45%;
+`;
+
+const DescriptionTerm = styled('dt')`
+  display: inline-block;
+  font-weight: 700;
+  margin: 0;
+  width: 12rem;
+`;
+
+const DescriptionDetails = styled('dd')`
+  display: inline-block;
+`;
+
+const StatBar = ({ children, percentage }) => {
+  return (
+    <StatListItem>
+      <Paragraph mb={1}>{statSlagToName.get(children)}</Paragraph>
+      <StatTrack>
+        <StatFill style={{ width: `${percentage}%` }}>{percentage}</StatFill>
+      </StatTrack>
+    </StatListItem>
+  );
+};
+
+const PokemonPage = ({ pokemon }) => {
+  return (
+    <>
+      <Head>
+        <title>Pokedex: {pokemon.name}</title>
+      </Head>
+
+      <HeaderWrapper>
+        <H2 mb={1}>
+          #{pokemon.number} - {pokemon.name}
+        </H2>
+
+        <ChipWrapper>
+          {pokemon.types.map((type) => (
+            <Chip key={type.slug} type={type.slug}>
+              {type.name}
+            </Chip>
+          ))}
+        </ChipWrapper>
+      </HeaderWrapper>
+
+      <InsightsWrapper>
+        <PokemonImage ratio="1 / 1">
+          <img
+            alt={`Image of ${pokemon.name}`}
+            draggable={false}
+            loading="lazy"
+            src={pokemon.artwork}
+          />
+        </PokemonImage>
+
+        <StatList>
+          {pokemon.stats.map((stat) => (
+            <StatBar key={stat.name} percentage={stat.value}>
+              {stat.name}
+            </StatBar>
+          ))}
+        </StatList>
+      </InsightsWrapper>
+
+      <ProfileWrapper>
+        <H3 mb={1}>{pokemon.genus}</H3>
+        <Paragraph>{pokemon.description}</Paragraph>
+
+        <DescriptionList>
+          <DescriptionSet>
+            <DescriptionTerm>Capture Rate</DescriptionTerm>
+            <DescriptionDetails>
+              {pokemon.captureRatePercentage}%
+            </DescriptionDetails>
+          </DescriptionSet>
+
+          <DescriptionSet>
+            <DescriptionTerm>Gender Split</DescriptionTerm>
+            <DescriptionDetails>
+              {pokemon.genderPercentages
+                ? `${pokemon.genderPercentages.male}% Male / ${pokemon.genderPercentages.female}% Female`
+                : 'N/A'}
+            </DescriptionDetails>
+          </DescriptionSet>
+
+          <DescriptionSet>
+            <DescriptionTerm>Height</DescriptionTerm>
+            <DescriptionDetails>
+              {pokemon.height.value}
+              {pokemon.height.unit}
+            </DescriptionDetails>
+          </DescriptionSet>
+
+          <DescriptionSet>
+            <DescriptionTerm>Weight</DescriptionTerm>
+            <DescriptionDetails>
+              {pokemon.weight.value}
+              {pokemon.weight.unit}
+            </DescriptionDetails>
+          </DescriptionSet>
+        </DescriptionList>
+
+        <TertiaryButton
+          href={`https://www.pokemon.com/us/pokedex/${pokemon.number}`}
+          target="_blank"
+        >
+          Go to Pokemon.com entry
+        </TertiaryButton>
+      </ProfileWrapper>
+    </>
+  );
+};
+
+export default PokemonPage;

--- a/pages/pokemon/index.jsx
+++ b/pages/pokemon/index.jsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import AspectRatioImage from 'components/aspect-ratio-image';
 import { PrimaryButtonLink } from 'components/button';
 import { H2, H3 } from 'components/typography';
-import { fetchKantoPokemon } from 'services/pokedex';
+import { fetchKantoPokemon } from 'services/pokeapi';
 import { spacing, typeScale } from 'utils/typography';
 
 const GridContainer = styled('div')`

--- a/services/pokeapi.js
+++ b/services/pokeapi.js
@@ -1,0 +1,111 @@
+import Decimal from 'decimal.js-light';
+
+const BASE_URL = 'https://pokeapi.co/api/v2';
+
+const convertHectogramsToKilograms = (value) => {
+  return new Decimal(value).dividedBy(10).toDecimalPlaces(2).toNumber();
+};
+
+const convertDecimetersToMeters = (value) => {
+  return new Decimal(value).dividedBy(10).toDecimalPlaces(2).toNumber();
+};
+
+const convertCaptureRateToPercentage = (captureRate) => {
+  return new Decimal(captureRate)
+    .dividedBy(255)
+    .times(100)
+    .toDecimalPlaces(2)
+    .toNumber();
+};
+
+const createGenderPercentages = (femaleRate) => {
+  if (femaleRate === -1) return null;
+
+  const femalePercentage = new Decimal(femaleRate)
+    .dividedBy(8)
+    .times(100)
+    .toNumber();
+
+  return {
+    male: 100 - femalePercentage,
+    female: femalePercentage,
+  };
+};
+
+const getEnglishRecord = (records) => {
+  return records.find((record) => record.language.name === 'en');
+};
+
+const extendWithTypes = async (pokemon, typeRecords) => {
+  const types = await Promise.all(
+    typeRecords.map(async ({ type: typeRecord }) => {
+      const typeResponse = await (await fetch(typeRecord.url)).json();
+
+      return {
+        slug: typeRecord.name,
+        name: getEnglishRecord(typeResponse.names).name,
+      };
+    })
+  );
+
+  return {
+    ...pokemon,
+    types,
+  };
+};
+
+export const fetchPokemon = async ({ slug, includeTypes = false }) => {
+  const pokemonResponse = fetch(`${BASE_URL}/pokemon/${slug}`);
+  const speciesResponse = fetch(`${BASE_URL}/pokemon-species/${slug}/`);
+
+  const [pokemonData, speciesData] = await Promise.all([
+    pokemonResponse.then((response) => response.json()),
+    speciesResponse.then((response) => response.json()),
+  ]);
+
+  const description = getEnglishRecord(
+    speciesData.flavor_text_entries
+  ).flavor_text.replace(/\n|\f/g, ' ');
+
+  const stats = pokemonData.stats.map((statRecord) => ({
+    name: statRecord.stat.name,
+    value: statRecord.base_stat,
+  }));
+
+  const pokemon = {
+    artwork: pokemonData.sprites.other['official-artwork'].front_default,
+    captureRatePercentage: convertCaptureRateToPercentage(
+      speciesData.capture_rate
+    ),
+    description,
+    genderPercentages: createGenderPercentages(speciesData.gender_rate),
+    genus: getEnglishRecord(speciesData.genera).genus,
+    height: {
+      value: convertDecimetersToMeters(pokemonData.height),
+      unit: 'm',
+    },
+    name: getEnglishRecord(speciesData.names).name,
+    number: pokemonData.id,
+    slug: pokemonData.name,
+    sprite: pokemonData.sprites.front_default,
+    stats,
+    weight: {
+      value: convertHectogramsToKilograms(pokemonData.weight),
+      unit: 'kg',
+    },
+  };
+
+  return includeTypes ? extendWithTypes(pokemon, pokemonData.types) : pokemon;
+};
+
+export const fetchKantoPokemon = async () => {
+  const pokemonData = await (
+    await fetch(`${BASE_URL}/pokemon?limit=151`)
+  ).json();
+
+  return await Promise.all(
+    pokemonData.results.map((record) =>
+      fetchPokemon({ slug: record.name, includeTypes: false })
+    )
+  );
+};


### PR DESCRIPTION
- Using margin props rather than CSS overrides.
- Adding service to interact with PokeAPI; it includes conversion methods to normalise metrics.
- Adding pokedex individual view page.

| Mobile View | Desktop View |
| --- | --- |
| ![pokedex_mobile](https://user-images.githubusercontent.com/167421/159377133-93b7f80c-eef2-47b4-aecd-73e1aa00e538.png) | ![pokemon_desktop](https://user-images.githubusercontent.com/167421/159377153-e97aba46-8865-482b-ad14-964577edd934.png) |
