### PR TITLE
fixing https protocol on font stylesheet

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -28,7 +28,7 @@ const App = ({ Component, pageProps }) => (
       />
       <link
         rel="stylesheet"
-        href="http://fonts.cdnfonts.com/css/pokemon-solid"
+        href="https://fonts.cdnfonts.com/css/pokemon-solid"
       />
     </Head>
     <Layout>


### PR DESCRIPTION
Updates the protocol on the font stylesheet to avoid the "Mixed Content" error of requesting HTTP locations while serving from an HTTPS location.