### PR TITLE
Pull Requests: Comments and Environments

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,9 +1,8 @@
 name: Vercel Preview Deploy
 
 on:
-  push:
-    branches-ignore:
-      - main
+  pull_request:
+    types: [reopened, opened, synchronize, edited]
 
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -42,4 +41,62 @@ jobs:
         run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy Project Artifacts to Vercel
-        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+        id: deploy-artifacts
+        run: |
+          echo "DEPLOY_URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})" >> $GITHUB_OUTPUT
+
+      - name: Upsert Pull Request Comment
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const COMMENT_PREFIX = 'Preview URL:';
+            const commentBody = `${COMMENT_PREFIX} [${{ steps.deploy-artifacts.outputs.DEPLOY_URL }}](${{ steps.deploy-artifacts.outputs.DEPLOY_URL }})`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            const existingComment = comments.find((comment) => {
+              return comment.body.startsWith(COMMENT_PREFIX);
+            });
+
+            if (existingComment) {
+              return await github.rest.issues.updateComment({
+                comment_id: existingComment.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: commentBody,
+              });
+            }
+
+            return await github.rest.issues.createComment({
+               issue_number: context.issue.number,
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               body: commentBody,
+            });
+
+      - name: Create Deployment
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const { data: deployment } = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: '${{ github.head_ref }}',
+              environment: 'Preview',
+              required_contexts: [],
+              auto_merge: false,
+            });
+
+            return await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.id,
+              state: 'success',
+              environment_url: '${{ steps.deploy-artifacts.outputs.DEPLOY_URL }}',
+            });

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -42,4 +42,28 @@ jobs:
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy Project Artifacts to Vercel
-        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        id: deploy-artifacts
+        run: |
+          echo "DEPLOY_URL=$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }})" >> $GITHUB_OUTPUT
+
+      - name: Create Deployment
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const { data: deployment } = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: '${{ github.head_ref }}',
+              environment: 'Production',
+              required_contexts: [],
+              auto_merge: false,
+            });
+
+            return await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.id,
+              state: 'success',
+              environment_url: '${{ steps.deploy-artifacts.outputs.DEPLOY_URL }}',
+            });


### PR DESCRIPTION
With Vercel interactions now moving in #23 to being run in CI/CD rather than their Git integration, this PR adds some developer quality of life improvements such as an environment associated with the PR to quickly access the deployed URL, and, a comment with the same URL (for convenience).

- Preview Workflow: Changing triggers from every push of every non-trunk branch - to - pull request specific events.
- Preview Workflow: Adding a comment with the Preview URL as it's body, then future workflow runs update the aforementioned comment.
- Both Workflows: Updating the "Deploy Artifacts" step to save the Vercel CLI output (which is the deploy URL) as an environment variable and then as the step's output.
- Both Workflows: Creating a deployment associated with the feature branch (as `ref`) and the relevant environment (`Preview` or `Production`), then, creating a deployment status to signal the deploy is successful and supply the deploy URL (`as environment_url`).

| PR Comment | PR Environment | Repository Deployments |
| ------------------ | ---------------------- | --------------------------------- |
| ![PR Comment](https://user-images.githubusercontent.com/167421/216831300-8bd3594e-019d-47bd-989b-48be2bfb2d77.png) | ![PR Environment](https://user-images.githubusercontent.com/167421/216831314-57bd93ac-1e2d-4de4-987d-121a899c8810.png) | ![Repository Deployments](https://user-images.githubusercontent.com/167421/216831253-d3aa8b52-8d9f-4d42-8c49-d303c60d0e90.png) |