### PR TITLE
Using "ref_name" on production pushes

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -54,7 +54,7 @@ jobs:
             const { data: deployment } = await github.rest.repos.createDeployment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: '${{ github.head_ref }}',
+              ref: '${{ github.ref_name }}',
               environment: 'Production',
               required_contexts: [],
               auto_merge: false,


### PR DESCRIPTION
Originally the production workflow for environments was using the copied/pasted script straight from the preview workflow. The problem is the preview workflow used `github.head_ref` for the `ref` of the GitHub Deployment. This only exists in `pull_request` triggers. For `push` events to the trunk, we need to use `github.ref_name`.