### PR TITLE
Fixing percy versions

### DIFF
--- a/cypress/integration/details-page.cy.js
+++ b/cypress/integration/details-page.cy.js
@@ -111,9 +111,5 @@ describe('Details Page', () => {
     );
 
     cy.findByText(/psychic/i).should('be.visible');
-
-    cy.percySnapshot('(Integration) Details page responsive test', {
-      widths: [600, Cypress.config('viewportWidth')],
-    });
   });
 });

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "start": "next start",
     "test:e2e:gui": "TEST_TYPE=e2e percy exec -- cypress open --e2e --browser=chrome",
     "test:e2e:headless": "TEST_TYPE=e2e percy exec -- cypress run --e2e --browser=chrome",
-    "test:integration:gui": "TEST_TYPE=integration percy exec -- cypress open --e2e --browser=chrome",
-    "test:integration:headless": "TEST_TYPE=integration percy exec -- cypress run --e2e --browser=chrome"
+    "test:integration:gui": "TEST_TYPE=integration cypress open --e2e --browser=chrome",
+    "test:integration:headless": "TEST_TYPE=integration cypress run --e2e --browser=chrome"
   },
   "dependencies": {
     "@emotion/react": "11.7.0",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   "devDependencies": {
     "@emotion/eslint-plugin": "11.7.0",
     "@next/bundle-analyzer": "12.0.7",
-    "@percy/cli": "^1.20.3",
-    "@percy/cypress": "^3.1.2",
+    "@percy/cli": "1.20.3",
+    "@percy/cypress": "3.1.2",
     "@stylelint/postcss-css-in-js": "0.37.2",
     "@testing-library/cypress": "8.0.7",
     "cypress": "11.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1634,7 +1634,7 @@
     fast-glob "^3.2.11"
     image-size "^1.0.0"
 
-"@percy/cli@^1.20.3":
+"@percy/cli@1.20.3":
   version "1.20.3"
   resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.20.3.tgz#66c3381f9d77f1d907026caa1fbb77fabec9cc42"
   integrity sha512-tH3MmMnnPU2dZWZ1J6N++ZJr2QOs2voUeg2p+SyqRNkry7wZRNQyFIO8awIbq+CErq5XkzeeIQ9WntvWACP9Kg==
@@ -1686,7 +1686,7 @@
     rimraf "^3.0.2"
     ws "^8.0.0"
 
-"@percy/cypress@^3.1.2":
+"@percy/cypress@3.1.2":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@percy/cypress/-/cypress-3.1.2.tgz#a087d3c59a6b155eab5fdb4c237526b9cfacbc22"
   integrity sha512-JXrGDZbqwkzQd2h5T5D7PvqoucNaiMh4ChPp8cLQiEtRuLHta9nf1lEuXH+jnatGL2j+3jJFIHJ0L7XrgVnvQA==


### PR DESCRIPTION
- Keeping versions fixed like all other dependencies are.
- Keeping visual regression testing as part of the end-to-end tests rather than integration tests.